### PR TITLE
Switch to micro-should

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "karma-chrome-launcher": "3.1.1",
     "karma-mocha": "2.0.1",
     "karma-mocha-reporter": "2.2.5",
+    "micro-should": "^0.3.0",
     "mocha": "10.0.0",
     "npm-run-all": "4.1.5",
     "parcel": "2.6.2",

--- a/test/test-vectors/aes.ts
+++ b/test/test-vectors/aes.ts
@@ -1,6 +1,8 @@
 import { decrypt, encrypt } from "../../src/aes";
 import { hexToBytes, toHex } from "../../src/utils";
 import { deepStrictEqual, rejects } from "./assert";
+import { describe, it } from "micro-should";
+
 // Test vectors taken from https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf
 const TEST_VECTORS = [
   {

--- a/test/test-vectors/bip39.ts
+++ b/test/test-vectors/bip39.ts
@@ -11,6 +11,7 @@ import { wordlist as japaneseWordlist } from "../../src/bip39/wordlists/japanese
 import { wordlist as spanishWordlist } from "../../src/bip39/wordlists/spanish";
 import { equalsBytes, hexToBytes, toHex } from "../../src/utils";
 import { deepStrictEqual, throws } from "./assert";
+import { describe, it } from "micro-should";
 
 describe("BIP39", () => {
   describe("Mnemonic generation", () => {

--- a/test/test-vectors/blake2b.ts
+++ b/test/test-vectors/blake2b.ts
@@ -1,6 +1,8 @@
 import { blake2b } from "../../src/blake2b";
 import { hexToBytes, toHex } from "../../src/utils";
 import { deepStrictEqual, throws } from "./assert";
+import { describe, it } from "micro-should";
+
 // Vectors extracted from https://github.com/emilbayes/blake2b/blob/f0a7c7b550133eca5f5fc3b751ccfd2335ce736f/test-vectors.json
 const TEST_VECTORS = [
   {

--- a/test/test-vectors/hdkey.ts
+++ b/test/test-vectors/hdkey.ts
@@ -2,6 +2,8 @@ import * as secp from "@noble/secp256k1";
 import { HARDENED_OFFSET, HDKey } from "../../src/hdkey";
 import { hexToBytes, toHex } from "../../src/utils";
 import { deepStrictEqual, throws } from "./assert";
+import { describe, it } from "micro-should";
+
 // https://github.com/cryptocoinjs/hdkey/blob/42637e381bdef0c8f785b14f5b66a80dad969514/test/fixtures/hdkey.json
 const fixtures = [
   {

--- a/test/test-vectors/index.ts
+++ b/test/test-vectors/index.ts
@@ -1,0 +1,21 @@
+import { it } from "micro-should";
+
+import * as aes from './aes';
+import * as ase from './assert';
+import * as bip from './bip39';
+import * as b2b from './blake2b';
+import * as hdk from './hdkey';
+import * as kec from './keccak';
+import * as pbk from './pbkdf2';
+import * as rand from './random';
+import * as md160 from './ripemd160';
+import * as scr from './scrypt';
+import * as cpt from './secp256k1-compat';
+import * as k1 from './secp256k1';
+import * as sha256 from './sha256';
+import * as sha512 from './sha512';
+
+// typescript
+[aes, ase, bip, b2b, hdk, kec, pbk, rand, md160, scr, cpt, k1, sha256, sha512];
+
+it.run();

--- a/test/test-vectors/keccak.ts
+++ b/test/test-vectors/keccak.ts
@@ -1,6 +1,7 @@
 import { keccak224, keccak256, keccak384, keccak512 } from "../../src/keccak";
 import { hexToBytes, toHex, utf8ToBytes } from "../../src/utils";
 import { deepStrictEqual } from "./assert";
+import { describe, it } from "micro-should";
 
 export const keccak224Vectors = [
   {

--- a/test/test-vectors/pbkdf2.ts
+++ b/test/test-vectors/pbkdf2.ts
@@ -1,6 +1,7 @@
 import { pbkdf2 as pbkdf2Async, pbkdf2Sync } from "../../src/pbkdf2";
 import { toHex, utf8ToBytes } from "../../src/utils";
 import { deepStrictEqual } from "./assert";
+import { describe, it } from "micro-should";
 
 const TEST_VECTORS = [
   {

--- a/test/test-vectors/random.ts
+++ b/test/test-vectors/random.ts
@@ -1,6 +1,7 @@
 import { getRandomBytes, getRandomBytesSync } from "../../src/random";
 import { equalsBytes } from "../../src/utils";
 import { deepStrictEqual } from "./assert";
+import { describe, it } from "micro-should";
 
 describe("Random number generation", () => {
   describe("Sync version", () => {

--- a/test/test-vectors/ripemd160.ts
+++ b/test/test-vectors/ripemd160.ts
@@ -1,6 +1,7 @@
 import { ripemd160 } from "../../src/ripemd160";
 import { toHex, utf8ToBytes } from "../../src/utils";
 import { deepStrictEqual } from "./assert";
+import { describe, it } from "micro-should";
 
 const TEST_VECTORS = [
   {

--- a/test/test-vectors/scrypt.ts
+++ b/test/test-vectors/scrypt.ts
@@ -1,6 +1,7 @@
 import { scrypt as scryptAsync, scryptSync } from "../../src/scrypt";
 import { hexToBytes, toHex } from "../../src/utils";
 import { deepStrictEqual } from "./assert";
+import { describe, it } from "micro-should";
 
 const TEST_VECTORS = [
   {
@@ -39,7 +40,7 @@ describe("scrypt", function() {
   describe("scrypt sync", function() {
     for (let i = 0; i < TEST_VECTORS.length; i++) {
       it(`Should process the test ${i} correctly`, function() {
-        this.timeout(10000)
+        // this.timeout(10000)
 
         const vector = TEST_VECTORS[i];
 
@@ -60,7 +61,7 @@ describe("scrypt", function() {
   describe("scrypt async", function() {
     for (let i = 0; i < TEST_VECTORS.length; i++) {
       it(`Should process the test ${i} correctly`, async function() {
-        this.timeout(10000);
+        // this.timeout(10000);
 
         const vector = TEST_VECTORS[i];
 

--- a/test/test-vectors/secp256k1-compat.ts
+++ b/test/test-vectors/secp256k1-compat.ts
@@ -3,6 +3,7 @@ import { sha256 } from "../../src/sha256";
 import { concatBytes, hexToBytes, toHex } from "../../src/utils";
 import { deepStrictEqual, throws } from "./assert";
 import { VECTORS } from "./secp256k1_lib_vectors";
+import { describe, it } from "micro-should";
 
 describe("secp256k1", function() {
   it("should create valid private keys", async function() {

--- a/test/test-vectors/secp256k1.ts
+++ b/test/test-vectors/secp256k1.ts
@@ -1,5 +1,6 @@
 import * as secp from "../../src/secp256k1";
 import { deepStrictEqual } from "./assert";
+import { describe, it } from "micro-should";
 
 describe("secp256k1", () => {
   it("should verify msg bb5a...", async () => {

--- a/test/test-vectors/sha256.ts
+++ b/test/test-vectors/sha256.ts
@@ -1,6 +1,7 @@
 import { sha256 } from "../../src/sha256";
 import { toHex, utf8ToBytes } from "../../src/utils";
 import { deepStrictEqual } from "./assert";
+import { describe, it } from "micro-should";
 
 const TEST_VECTORS = [
   {

--- a/test/test-vectors/sha512.ts
+++ b/test/test-vectors/sha512.ts
@@ -1,6 +1,7 @@
 import { sha512 } from "../../src/sha512";
 import { toHex, utf8ToBytes } from "../../src/utils";
 import { deepStrictEqual } from "./assert";
+import { describe, it } from "micro-should";
 
 const TEST_VECTORS = [
   {


### PR DESCRIPTION
### Description

In this pull request, several modifications and additions have been made to the test vectors across various test files in the project. Additionally, a new test-vectors/index.ts file has been added to aggregate and run tests for all modules. Here's a summary of the changes:

- Added `micro-should` as a new dependency.
- Added `describe` and `it` imports from `micro-should` to the test files.
- Added an `index.ts` file to aggregate and run tests from all modules.

List of changes:
- Added `import { describe, it } from "micro-should";` to the following test files: `aes.ts`, `bip39.ts`, `blake2b.ts`, `hdkey.ts`, `keccak.ts`, `pbkdf2.ts`, `random.ts`, `ripemd160.ts`, `scrypt.ts`, `secp256k1-compat.ts`, `secp256k1.ts`, `sha256.ts`, `sha512.ts`.
- Added a new `test/test-vectors/index.ts` file to run tests for all modules.

These changes aim to enhance the test structure and organization in the project by using the `micro-should` testing library and aggregating tests into a single file.